### PR TITLE
Create instances of commands instead of handling them as singletons

### DIFF
--- a/src/event/clientReady.ts
+++ b/src/event/clientReady.ts
@@ -13,7 +13,7 @@ import { setupDailyCleanupCronjob } from "../cronjob/dailyCleanup";
 import { setupHourlyCleanupCronjob } from "../cronjob/hourlyCleanup";
 import env from "../env";
 import { tSetup } from "../i18n";
-import commandsMap from "../map/commandsMap";
+import { commandsMap } from "../map/commandsMap";
 
 export default function onClientReady(client: Client): void {
     client.on(Events.ClientReady, async () => {
@@ -43,7 +43,8 @@ export default function onClientReady(client: Client): void {
         const commandJSONs: RESTPostAPIApplicationCommandsJSONBody[] = [];
 
         for (const command of commandsMap.values()) {
-            commandJSONs.push(command.buildSlashCommandJSON());
+            const tmpInstance = new command();
+            commandJSONs.push(tmpInstance.buildSlashCommandJSON());
         }
 
         const rest: REST = new REST({ version: "10" }).setToken(env.BOT_TOKEN);

--- a/src/event/interactionCreate.ts
+++ b/src/event/interactionCreate.ts
@@ -8,10 +8,9 @@ import {
     ModalSubmitInteraction,
 } from "discord.js";
 import { AbstractButton } from "../button/AbstractButton";
-import { AbstractCommand } from "../command/AbstractCommand";
 import { dynamicIdRegExp } from "../constant/dynamicIdRegExp";
 import { buttonsMap } from "../map/buttonsMap";
-import commandsMap from "../map/commandsMap";
+import { commandsMap } from "../map/commandsMap";
 import { modalSubmitsMap } from "../map/modalSubmitsMap";
 import { AbstractModalSubmit } from "../modal/submit/AbstractModalSubmit";
 
@@ -38,11 +37,15 @@ export default function onInteractionCreate(client: Client): void {
 }
 
 async function handleCommand(interaction: ChatInputCommandInteraction): Promise<void> {
-    const command: AbstractCommand | undefined = commandsMap.get(interaction.commandName);
-    if (!command) return;
+    const command = commandsMap.get(interaction.commandName);
+
+    if (!command) {
+        return;
+    }
 
     try {
-        await command.execute(interaction);
+        const commandInstance = new command();
+        await commandInstance.execute(interaction);
     } catch (error) {
         console.error(error);
         if (interaction.isRepliable()) {

--- a/src/map/commandsMap.ts
+++ b/src/map/commandsMap.ts
@@ -5,17 +5,17 @@ import { MeetupCommand } from "../command/MeetupCommand";
 import { MeetupRemoveMentionRoleCommand } from "../command/MeetupRemoveMentionRole";
 import { PollCommand } from "../command/PollCommand";
 
-const commands: AbstractCommand[] = [
-    new MeetupCommand(),
-    new MeetupAddMentionRoleCommand(),
-    new MeetupRemoveMentionRoleCommand(),
-    new MeetupCleanUpCommand(),
-    new PollCommand(),
+const commandClasses: Array<new () => AbstractCommand> = [
+    MeetupCommand,
+    MeetupAddMentionRoleCommand,
+    MeetupRemoveMentionRoleCommand,
+    MeetupCleanUpCommand,
+    PollCommand,
 ];
 
-export const commandsMap: Map<string, AbstractCommand> = new Map();
-for (const cmd of commands) {
-    commandsMap.set(cmd.name, cmd);
-}
+export const commandsMap = new Map<string, new () => AbstractCommand>();
 
-export default commandsMap;
+for (const CommandClass of commandClasses) {
+    const tmpInstance = new CommandClass();
+    commandsMap.set(tmpInstance.name, CommandClass);
+}


### PR DESCRIPTION
Currently, when the bot starts up, a single instance of each command is created and reused throughout its lifetime, effectively acting as a singleton. Commands do not store any state at the moment, but this may change in the future.

In this PR a new instance of a command will be created each time a user executes it.