### PR TITLE
Restore modal input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ MEETUP_DELETE_LIMIT_HOURS=3
 # DESC = latest meetups first
 MEETUP_LIST_SORT_ORDER=ASC
 
+# Hours after a created modal input draft can exist before it can be deleted by cleanup actions
+MODAL_INPUT_DRAFT_DELETE_LIMIT_HOURS=24
+
 # Database configuration used by Curveball Bot
 DB_HOST=
 DB_PORT=

--- a/src/cleanup/deleteOldModalInputDrafts.ts
+++ b/src/cleanup/deleteOldModalInputDrafts.ts
@@ -1,0 +1,18 @@
+import { db } from "../database/Database";
+import env from "../env";
+
+/**
+ * Function for deleting old modal input drafts
+ */
+
+export async function deleteOldModalInputDrafts(): Promise<void> {
+    //detect old modal input drafts
+    const dateNow = new Date();
+    const deleteLimitHours: number = 3600000 * env.MODAL_INPUT_DRAFT_DELETE_LIMIT_HOURS;
+    const deleteLimitDate = new Date(dateNow.getTime() - deleteLimitHours);
+
+    await db
+        .deleteFrom("modal_input_draft")
+        .where("createTime", "<", deleteLimitDate)
+        .execute();
+}

--- a/src/cronjob/dailyCleanup.ts
+++ b/src/cronjob/dailyCleanup.ts
@@ -1,5 +1,6 @@
 import nodeCron from "node-cron";
 import { deleteNonBotMessagesFromCreateChannel } from "../cleanup/deleteNonBotMessagesFromCreateChannel";
+import { deleteOldModalInputDrafts } from "../cleanup/deleteOldModalInputDrafts";
 import { deleteRedundantMeetupRoles } from "../cleanup/deleteRedundantMeetupRoles";
 import { deleteRedundantMeetupThreads } from "../cleanup/deleteRedundantMeetupThreads";
 import { tCronjob, tSetup } from "../i18n";
@@ -23,6 +24,8 @@ async function runCleanup(): Promise<void> {
     await deleteRedundantMeetupThreads();
     await deleteRedundantMeetupRoles();
     await deleteNonBotMessagesFromCreateChannel();
+
+    await deleteOldModalInputDrafts();
 }
 
 

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -4,11 +4,13 @@ import env from "../env";
 import { Meetup } from "./table/Meetup";
 import { MeetupAllowedMentionsRole } from "./table/MeetupAllowedMentionsRole";
 import { MeetupParticipant } from "./table/MeetupParticipant";
+import { ModalInputDraft } from "./table/ModalInputDraft";
 
 export interface Database {
     meetup: Meetup;
     meetup_participant: MeetupParticipant;
     meetup_allowed_mentions_role: MeetupAllowedMentionsRole;
+    modal_input_draft: ModalInputDraft;
 }
 
 export const db = new Kysely<Database>({

--- a/src/database/migration/20260706_001_modal_input_draft.ts
+++ b/src/database/migration/20260706_001_modal_input_draft.ts
@@ -19,7 +19,7 @@ function createModalInputDraftTable(db: Kysely<any>): Promise<void> {
             (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder => col.notNull(),
         )
         .addColumn(
-            "modalCustomID",
+            "draftCustomID",
             "varchar(100)",
             (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder => col.notNull(),
         )
@@ -37,7 +37,7 @@ function createModalInputDraftTable(db: Kysely<any>): Promise<void> {
         .addPrimaryKeyConstraint("modal_input_draft_pk",
             [
                 "userID",
-                "modalCustomID",
+                "draftCustomID",
             ]
         )
         .execute();

--- a/src/database/migration/20260706_001_modal_input_draft.ts
+++ b/src/database/migration/20260706_001_modal_input_draft.ts
@@ -1,0 +1,50 @@
+import { ColumnDefinitionBuilder, Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await createModalInputDraftTable(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await dropModalInputDraftTable(db);
+}
+
+// === up ===
+
+function createModalInputDraftTable(db: Kysely<any>): Promise<void> {
+    return db.schema
+        .createTable("modal_input_draft")
+        .addColumn(
+            "userID",
+            "varchar(32)",
+            (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder => col.notNull(),
+        )
+        .addColumn(
+            "modalCustomID",
+            "varchar(100)",
+            (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder => col.notNull(),
+        )
+        .addColumn(
+            "formData",
+            "json",
+            (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder => col.notNull(),
+        )
+        .addColumn(
+            "createTime",
+            "timestamp",
+            (col: ColumnDefinitionBuilder): ColumnDefinitionBuilder =>
+                col.defaultTo(sql`CURRENT_TIMESTAMP`),
+        )
+        .addPrimaryKeyConstraint("modal_input_draft_pk",
+            [
+                "userID",
+                "modalCustomID",
+            ]
+        )
+        .execute();
+}
+
+// === down ===
+
+function dropModalInputDraftTable(db: Kysely<any>): Promise<void> {
+    return db.schema.dropTable("modal_input_draft").execute();
+}

--- a/src/database/table/ModalInputDraft.ts
+++ b/src/database/table/ModalInputDraft.ts
@@ -3,30 +3,29 @@ import { Database, db } from "../Database";
 
 export interface ModalInputDraft {
     userID: string;
-    modalCustomID: string;
-    formData: Record<string, unknown>;
+    draftCustomID: string;
+    formData: string; //json
 
     createTime: Generated<Date | null>;
 }
 
 export type ModalInputDraftRow = Selectable<Database["modal_input_draft"]>;
 
-export async function getModalInputDrafts(userID: string, modalCustomID: string): Promise<ModalInputDraftRow[]> {
+export async function getModalInputDrafts(userID: string, draftCustomID: string): Promise<ModalInputDraftRow | undefined> {
     return (await db
         .selectFrom("modal_input_draft")
         .selectAll()
         .where("userID", "=", userID)
-        .where("modalCustomID", "=", modalCustomID)
-        .execute()) as ModalInputDraftRow[];
+        .where("draftCustomID", "=", draftCustomID)
+        .executeTakeFirst()) as ModalInputDraftRow | undefined;
 }
 
 export async function deleteModalInputDrafts(
     userIDs: string[],
-    modalCustomID: string,
+    draftCustomID: string,
 ): Promise<DeleteResult[]> {
     return await db.deleteFrom("modal_input_draft")
         .where("userID", "in", userIDs)
-        .where("modalCustomID", "=", modalCustomID)
+        .where("draftCustomID", "=", draftCustomID)
         .execute();
 }
-

--- a/src/database/table/ModalInputDraft.ts
+++ b/src/database/table/ModalInputDraft.ts
@@ -1,0 +1,32 @@
+import { DeleteResult, Generated, Selectable } from "kysely";
+import { Database, db } from "../Database";
+
+export interface ModalInputDraft {
+    userID: string;
+    modalCustomID: string;
+    formData: Record<string, unknown>;
+
+    createTime: Generated<Date | null>;
+}
+
+export type ModalInputDraftRow = Selectable<Database["modal_input_draft"]>;
+
+export async function getModalInputDrafts(userID: string, modalCustomID: string): Promise<ModalInputDraftRow[]> {
+    return (await db
+        .selectFrom("modal_input_draft")
+        .selectAll()
+        .where("userID", "=", userID)
+        .where("modalCustomID", "=", modalCustomID)
+        .execute()) as ModalInputDraftRow[];
+}
+
+export async function deleteModalInputDrafts(
+    userIDs: string[],
+    modalCustomID: string,
+): Promise<DeleteResult[]> {
+    return await db.deleteFrom("modal_input_draft")
+        .where("userID", "in", userIDs)
+        .where("modalCustomID", "=", modalCustomID)
+        .execute();
+}
+

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
-import { getPositiveNumberFromString } from "./util/getPositiveNumberFromString";
 import { OrderByModifiers } from "kysely";
+import { getPositiveNumberFromString } from "./util/getPositiveNumberFromString";
 
 declare type envStruct = {
     BOT_TOKEN: string;
@@ -14,6 +14,7 @@ declare type envStruct = {
     MEETUP_CREATE_DISABLE_DEFAULT_NOTICES: boolean;
     MEETUP_DELETE_LIMIT_HOURS: number;
     MEETUP_LIST_SORT_ORDER: OrderByModifiers;
+    MODAL_INPUT_DRAFT_DELETE_LIMIT_HOURS: number;
     DB_HOST: string;
     DB_PORT: string;
     DB_USERNAME: string;
@@ -36,6 +37,7 @@ const env: envStruct = {
         process.env.MEETUP_CREATE_DISABLE_DEFAULT_NOTICES === "true",
     MEETUP_DELETE_LIMIT_HOURS: getPositiveNumberFromString(process.env.MEETUP_DELETE_LIMIT_HOURS),
     MEETUP_LIST_SORT_ORDER: (process.env.MEETUP_LIST_SORT_ORDER?.toLocaleLowerCase() === "asc" ? "asc" : "desc"),
+    MODAL_INPUT_DRAFT_DELETE_LIMIT_HOURS: getPositiveNumberFromString(process.env.MODAL_INPUT_DRAFT_DELETE_LIMIT_HOURS),
     DB_HOST: process.env.DB_HOST || "",
     DB_PORT: process.env.DB_PORT || "",
     DB_USERNAME: process.env.DB_USERNAME || "",

--- a/src/locale/en/modal.ts
+++ b/src/locale/en/modal.ts
@@ -5,7 +5,10 @@ const modal: TranslationObject = {
         error: {
             invalidInteractionType: "Invalid interaction type",
             invalidCommand: "Invalid command {{commandName}}",
+            unknown: "Unknown error",
         },
+
+        placeholder: "Placeholder",
     },
 
     meetupCreate: {

--- a/src/locale/en/modal.ts
+++ b/src/locale/en/modal.ts
@@ -5,6 +5,7 @@ const modal: TranslationObject = {
         error: {
             invalidInteractionType: "Invalid interaction type",
             invalidCommand: "Invalid command {{commandName}}",
+            draft: "Failed to save modal input draft",
             unknown: "Unknown error",
         },
 

--- a/src/modal/AbstractModal.ts
+++ b/src/modal/AbstractModal.ts
@@ -1,4 +1,6 @@
-import { ButtonInteraction, ChatInputCommandInteraction, ModalBuilder } from "discord.js";
+import { ButtonInteraction, ChatInputCommandInteraction, LabelBuilder, ModalBuilder } from "discord.js";
+import { getModalInputDrafts, ModalInputDraftRow } from "../database/table/ModalInputDraft";
+import { tModal } from "../i18n";
 import { postError } from "../util/postEmbeds";
 
 /**
@@ -9,6 +11,13 @@ export abstract class AbstractModal {
     public readonly customId!: string;
     protected submitCustomId!: string;
     protected additionalData: Record<string, any> = {};
+    protected interactionUserID: string = "";
+    protected draftCustomID: string = "";
+    protected useDraftAsInputRestore: boolean = true;
+
+    protected get modalTitle(): string {
+        return tModal("global.placeholder");
+    }
 
     /**
      * Prepares and displays modal
@@ -18,12 +27,14 @@ export abstract class AbstractModal {
     ): Promise<void> {
         try {
             await this.checkPermissions(interaction);
-            this.setSubmitCustomId();
-            const modal: ModalBuilder = this.buildModal();
+            this.setSubmitCustomID();
+            this.setDraftCustomID();
+            this.setInteractionUserID(interaction);
+            const modal: ModalBuilder = await this.buildModal();
             await this.preShowModal(interaction);
             await interaction.showModal(modal);
         } catch (error) {
-            let errorMessage: string = "Unbekannter Fehler";
+            let errorMessage: string = tModal("global.error.unknown");
 
             if (error instanceof Error) {
                 errorMessage = error.message;
@@ -43,13 +54,65 @@ export abstract class AbstractModal {
     /**
      * Builds modal including input fields
      */
-    protected abstract buildModal(): ModalBuilder;
+    protected async buildModal(): Promise<ModalBuilder> {
+        const modal: ModalBuilder = new ModalBuilder()
+            .setCustomId(this.submitCustomId)
+            .setTitle(this.modalTitle);
+
+        const inputs = this.buildInputs();
+        await this.setInputValues(inputs);
+
+        modal.addLabelComponents(...Object.values(inputs));
+
+        return modal;
+    }
 
     /**
-     * Sets customId for modal submit
+     * Builds modal including input fields
      */
-    protected setSubmitCustomId(): void {
+    protected abstract buildInputs(): Record<string, LabelBuilder>;
+
+    /**
+     * Sets the values of the modal's input fields.
+     * 
+     * May be ignored if an unexpected error occurs and discord applies its own draft.
+     */
+    protected async setInputValues(inputs: Record<string, LabelBuilder>): Promise<void> {
+        if(this.useDraftAsInputRestore) {
+            //search for draft if available
+            const draft = await getModalInputDrafts(this.interactionUserID, this.draftCustomID);
+
+            if(draft){
+                this.applyDraftInputValues(inputs, draft);
+                return;
+            }
+        }
+
+        await this.applyDefaultInputValues(inputs);
+    };
+
+    /**
+     * Applies values from draft on input fields
+     */
+    protected async applyDraftInputValues(inputs: Record<string, LabelBuilder>, draft: ModalInputDraftRow): Promise<void> {};
+
+    /**
+     * Default behaviour for applying values on input fields (e.g. from database or just do nothing)
+     */
+    protected async applyDefaultInputValues(inputs: Record<string, LabelBuilder>): Promise<void> {};
+
+    /**
+     * Sets customID for modal submit
+     */
+    protected setSubmitCustomID(): void {
         this.submitCustomId = this.customId;
+    }
+
+    /**
+     * Sets customId for modal input draft
+     */
+    protected setDraftCustomID(): void {
+        this.draftCustomID = this.customId;
     }
 
     /**
@@ -65,4 +128,13 @@ export abstract class AbstractModal {
     protected async checkPermissions(
         interaction: ChatInputCommandInteraction | ButtonInteraction,
     ): Promise<void> {}
+
+    /**
+     * Sets the user ID of the user who opened the modal
+     */
+    private setInteractionUserID(interaction: ChatInputCommandInteraction | ButtonInteraction): void {
+        if(interaction.user.id){
+            this.interactionUserID = interaction.user.id;
+        }
+    }
 }

--- a/src/modal/MeetupCreateModal.ts
+++ b/src/modal/MeetupCreateModal.ts
@@ -2,12 +2,12 @@ import {
     ButtonInteraction,
     ChatInputCommandInteraction,
     LabelBuilder,
-    ModalBuilder,
     TextInputBuilder,
-    TextInputStyle,
+    TextInputStyle
 } from "discord.js";
 import { db } from "../database/Database";
 import { MeetupAllowedMentionsRoleRow } from "../database/table/MeetupAllowedMentionsRole";
+import { ModalInputDraftRow } from "../database/table/ModalInputDraft";
 import { tModal } from "../i18n";
 import { AbstractModal } from "./AbstractModal";
 
@@ -66,25 +66,17 @@ export class MeetupCreateModal extends AbstractModal {
         });
     }
 
-    protected setSubmitCustomId() {
+    protected setSubmitCustomID() {
         const roleIdString = this.additionalData.roleIds.join(",");
 
         this.submitCustomId = "meetup_create:" + roleIdString;
     }
 
-    protected buildModal(): ModalBuilder {
-        const modal: ModalBuilder = new ModalBuilder()
-            .setCustomId(this.submitCustomId)
-            .setTitle(this.modalTitle);
-
-        const { pokemon, location, time, date, note } = this.buildInputs();
-        // Add inputs to the modal
-        modal.addLabelComponents(pokemon, location, time, date, note);
-
-        return modal;
+    protected setDraftCustomID(): void {
+        this.draftCustomID = "meetup_create";
     }
 
-    protected buildInputs() {
+    protected buildInputs(): Record<string, LabelBuilder> {
         const pokemonInput: TextInputBuilder = new TextInputBuilder()
             .setCustomId("pokemon")
             .setPlaceholder(tModal("meetupCreate.field.pokemonPlaceholder"))
@@ -149,6 +141,42 @@ export class MeetupCreateModal extends AbstractModal {
             note: note,
         };
     }
+
+    protected async applyDraftInputValues(inputs: Record<string, LabelBuilder>, draft: ModalInputDraftRow): Promise<void> {
+        const { pokemon, location, time, date, note } = inputs;
+
+        const formData = JSON.parse(draft.formData);
+
+        // pokemon
+        if(formData.pokemon !== undefined) {
+            const pokemonInput = pokemon.data.component as TextInputBuilder;
+            pokemonInput.setValue(String(formData.pokemon));
+        }
+
+        // location
+        if(formData.location !== undefined) {
+            const locationInput = location.data.component as TextInputBuilder;
+            locationInput.setValue(String(formData.location));
+        }
+
+        // time
+        if(formData.time !== undefined) {
+            const timeInput = time.data.component as TextInputBuilder;
+            timeInput.setValue(String(formData.time));
+        }
+
+        // date
+        if(formData.date !== undefined) {
+            const dateInput = date.data.component as TextInputBuilder;
+            dateInput.setValue(String(formData.date));
+        }
+
+        // note
+        if(formData.note !== undefined) {
+            const noteInput = note.data.component as TextInputBuilder;
+            noteInput.setValue(String(formData.note));
+        }
+    };
 
     private async checkRole(roleId: string): Promise<void> {
         const role = (await db

--- a/src/modal/MeetupEditModal.ts
+++ b/src/modal/MeetupEditModal.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, ChatInputCommandInteraction, TextInputBuilder } from "discord.js";
+import { ButtonInteraction, ChatInputCommandInteraction, LabelBuilder, TextInputBuilder } from "discord.js";
 import { MeetupRow } from "../database/table/Meetup";
 import { tModal } from "../i18n";
 import { assertMeetupIDIsValid } from "../permission/assertMeetupIDIsValid";
@@ -33,13 +33,18 @@ export class MeetupEditModal extends MeetupCreateModal {
         });
     }
 
-    protected setSubmitCustomId() {
+    protected setSubmitCustomID() {
         this.submitCustomId = "meetup_edit:" + this.additionalData.meetup.meetupID;
     }
 
-    protected buildInputs() {
-        const { pokemon, location, time, date, note } = super.buildInputs();
+    protected setDraftCustomID(): void {
+        this.draftCustomID = this.submitCustomId;
+    }
 
+    protected async applyDefaultInputValues(inputs: Record<string, LabelBuilder>): Promise<void> {
+        const { pokemon, location, time, date, note } = inputs;
+
+        //use meetup data from database as default
         const meetup = this.additionalData.meetup as MeetupRow;
 
         //set values
@@ -70,13 +75,5 @@ export class MeetupEditModal extends MeetupCreateModal {
             const noteInput = note.data.component as TextInputBuilder;
             noteInput.setValue(meetup.note);
         }
-
-        return {
-            pokemon: pokemon,
-            location: location,
-            time: time,
-            date: date,
-            note: note,
-        };
-    }
+    };
 }

--- a/src/modal/NoticeCreateModal.ts
+++ b/src/modal/NoticeCreateModal.ts
@@ -2,13 +2,13 @@ import {
     ButtonInteraction,
     ChatInputCommandInteraction,
     LabelBuilder,
-    ModalBuilder,
     ModalSubmitInteraction,
     StringSelectMenuBuilder,
     StringSelectMenuOptionBuilder,
     TextInputBuilder,
-    TextInputStyle,
+    TextInputStyle
 } from "discord.js";
+import { ModalInputDraftRow } from "../database/table/ModalInputDraft";
 import { tModal } from "../i18n";
 import { AbstractModal } from "./AbstractModal";
 
@@ -41,22 +41,11 @@ export class NoticeCreateModal extends AbstractModal {
         }
     }
 
-    protected setSubmitCustomId() {
+    protected setSubmitCustomID() {
         this.submitCustomId = "notice_create";
     }
 
-    protected buildModal(): ModalBuilder {
-        const modal: ModalBuilder = new ModalBuilder()
-            .setCustomId(this.submitCustomId)
-            .setTitle(this.modalTitle);
-
-        const { title, description, type } = this.buildInputs();
-        modal.addLabelComponents(title, description, type);
-
-        return modal;
-    }
-
-    protected buildInputs() {
+    protected buildInputs(): Record<string, LabelBuilder> {
         const titleInput: TextInputBuilder = new TextInputBuilder()
             .setCustomId("title")
             .setPlaceholder(tModal("noticeCreate.field.titlePlaceholder"))
@@ -103,4 +92,28 @@ export class NoticeCreateModal extends AbstractModal {
             type: type,
         };
     }
+
+    protected async applyDraftInputValues(inputs: Record<string, LabelBuilder>, draft: ModalInputDraftRow): Promise<void> {
+        const { title, description, type } = inputs;
+
+        const formData = JSON.parse(draft.formData);
+
+        // title
+        if(formData.title !== undefined) {
+            const titleInput = title.data.component as TextInputBuilder;
+            titleInput.setValue(String(formData.title));
+        }
+
+        // description
+        if(formData.description !== undefined) {
+            const descriptionInput = description.data.component as TextInputBuilder;
+            descriptionInput.setValue(String(formData.description));
+        }
+
+        // type
+        if(formData.type !== undefined) {
+            const typeInput = type.data.component as TextInputBuilder;
+            typeInput.setValue(String(formData.type));
+        }
+    };
 }

--- a/src/modal/NoticeEditModal.ts
+++ b/src/modal/NoticeEditModal.ts
@@ -1,6 +1,7 @@
 import {
     ChatInputCommandInteraction,
     Embed,
+    LabelBuilder,
     Message,
     StringSelectMenuBuilder,
     TextInputBuilder,
@@ -42,13 +43,14 @@ export class NoticeEditModal extends NoticeCreateModal {
         });
     }
 
-    protected setSubmitCustomId() {
+    protected setSubmitCustomID() {
         this.submitCustomId = "notice_edit:" + this.additionalData.message.id;
     }
 
-    protected buildInputs() {
-        const { title, description, type } = super.buildInputs();
+     protected async applyDefaultInputValues(inputs: Record<string, LabelBuilder>): Promise<void> {
+        const { title, description, type } = inputs;
 
+        //use message embed directly as default
         const message = this.additionalData.message as Message;
         const embed: Embed = message.embeds[0];
 
@@ -62,11 +64,5 @@ export class NoticeEditModal extends NoticeCreateModal {
 
         const typeInput = type.data.component as StringSelectMenuBuilder;
         //TODO set type
-
-        return {
-            title: title,
-            description: description,
-            type: type,
-        };
-    }
+    };
 }

--- a/src/modal/submit/AbstractModalSubmit.ts
+++ b/src/modal/submit/AbstractModalSubmit.ts
@@ -1,7 +1,9 @@
 import { MessageFlags, ModalSubmitFields, ModalSubmitInteraction } from "discord.js";
+import { InteractionResponseMode } from "../../constant/interactionResponseMode";
+import { db } from "../../database/Database";
+import { deleteModalInputDrafts } from "../../database/table/ModalInputDraft";
 import { tCommon } from "../../i18n";
 import { postError } from "../../util/postEmbeds";
-import { InteractionResponseMode } from "../../constant/interactionResponseMode";
 
 /**
  * Base class for all modals submit handlers for Curveball Bot.
@@ -13,6 +15,9 @@ export abstract class AbstractModalSubmit {
     protected sanitizedInputs: Record<string, any> = {};
     protected additionalData: Record<string, any> = {};
     protected responseMode = InteractionResponseMode.UPDATE;
+    protected saveInputDraftOnError: boolean = true;
+    protected interactionUserID: string = "";
+    protected draftCustomID: string = "";
 
     /**
      * Handles user inputs from modal
@@ -20,8 +25,11 @@ export abstract class AbstractModalSubmit {
     public async execute(interaction: ModalSubmitInteraction): Promise<void> {
         try {
             await this.prepareResponse(interaction);
+            this.setInteractionUserID(interaction);
+            this.setDraftCustomID(interaction);
             await this.checkPermissions(interaction);
-            this.checkModalInputs(interaction.fields);
+            this.sanitizeModalInputs(interaction.fields);
+            this.validateModalInputs();
             await this.successModalInputs(interaction);
         } catch (error) {
             let errorMessage: string = tCommon("error.unknown");
@@ -47,9 +55,14 @@ export abstract class AbstractModalSubmit {
     protected async checkPermissions(interaction: ModalSubmitInteraction): Promise<void> {}
 
     /**
+     * Sanitizes and stores the modal input values
+     */
+    protected sanitizeModalInputs(fields: ModalSubmitFields): void {}
+
+    /**
      * Checks and verifies user inputs of this modal
      */
-    protected checkModalInputs(fields: ModalSubmitFields): void {}
+    protected validateModalInputs(): void {}
 
     /**
      * Called after user inputs of this modal have been successfully verified
@@ -57,9 +70,53 @@ export abstract class AbstractModalSubmit {
     protected async successModalInputs(interaction: ModalSubmitInteraction): Promise<void> {}
 
     /**
+     * Handles validation errors for modal inputs
+     */
+    protected handleError(errorMessage: string): Promise<void> {
+        if(this.saveInputDraftOnError){
+            this.saveModalInputDraft();
+        }
+
+        throw new Error(errorMessage);
+    }
+
+    /**
+     * Deletes all saved drafts for the current user and modal
+     */
+    protected async deleteModalInputDraft(): Promise<void> {
+       await deleteModalInputDrafts([this.interactionUserID], this.draftCustomID);
+    }
+
+    /**
+     * Saves the current modal inputs so they can be restored when the user reopens the modal
+     */
+    private async saveModalInputDraft(): Promise<void> {
+        await db
+            .insertInto("modal_input_draft")
+            .values({
+                userID: this.interactionUserID,
+                draftCustomID: this.draftCustomID,
+                formData: JSON.stringify(this.sanitizedInputs)
+            })
+            .onDuplicateKeyUpdate({
+                formData: JSON.stringify(this.sanitizedInputs),
+            })
+            .executeTakeFirstOrThrow();
+    }
+
+    /**
+     * Sets customId for modal input draft
+     */
+    protected setDraftCustomID(interaction: ModalSubmitInteraction): void {
+        if(interaction.customId){
+            this.draftCustomID = interaction.customId;
+        }
+    }
+
+    /**
      * Sets the interaction response for this modal submit. Run this as early as possible after a submit to prevent timeout errors
      */
-    private async prepareResponse(interaction: ModalSubmitInteraction) {
+    private async prepareResponse(interaction: ModalSubmitInteraction): Promise<void> {
         switch(this.responseMode){
             case InteractionResponseMode.UPDATE:
                 await interaction.deferUpdate();
@@ -72,6 +129,15 @@ export abstract class AbstractModalSubmit {
             case InteractionResponseMode.NONE:
                 //do nothing;
                 break;
+        }
+    }
+
+    /**
+     * Sets the userID of the user who submitted the modal
+     */
+    private setInteractionUserID(interaction: ModalSubmitInteraction): void {
+        if(interaction.user.id){
+            this.interactionUserID = interaction.user.id;
         }
     }
 }

--- a/src/modal/submit/AbstractModalSubmit.ts
+++ b/src/modal/submit/AbstractModalSubmit.ts
@@ -2,7 +2,7 @@ import { MessageFlags, ModalSubmitFields, ModalSubmitInteraction } from "discord
 import { InteractionResponseMode } from "../../constant/interactionResponseMode";
 import { db } from "../../database/Database";
 import { deleteModalInputDrafts } from "../../database/table/ModalInputDraft";
-import { tCommon } from "../../i18n";
+import { tCommon, tModal } from "../../i18n";
 import { postError } from "../../util/postEmbeds";
 
 /**
@@ -25,9 +25,9 @@ export abstract class AbstractModalSubmit {
     public async execute(interaction: ModalSubmitInteraction): Promise<void> {
         try {
             await this.prepareResponse(interaction);
+            await this.checkPermissions(interaction);
             this.setInteractionUserID(interaction);
             this.setDraftCustomID(interaction);
-            await this.checkPermissions(interaction);
             this.sanitizeModalInputs(interaction.fields);
             this.validateModalInputs();
             await this.successModalInputs(interaction);
@@ -91,17 +91,23 @@ export abstract class AbstractModalSubmit {
      * Saves the current modal inputs so they can be restored when the user reopens the modal
      */
     private async saveModalInputDraft(): Promise<void> {
-        await db
-            .insertInto("modal_input_draft")
-            .values({
-                userID: this.interactionUserID,
-                draftCustomID: this.draftCustomID,
-                formData: JSON.stringify(this.sanitizedInputs)
-            })
-            .onDuplicateKeyUpdate({
-                formData: JSON.stringify(this.sanitizedInputs),
-            })
-            .executeTakeFirstOrThrow();
+        try {
+            const formData = JSON.stringify(this.sanitizedInputs);  
+
+            await db
+                .insertInto("modal_input_draft")
+                .values({
+                    userID: this.interactionUserID,
+                    draftCustomID: this.draftCustomID,
+                    formData: formData,
+                })
+                .onDuplicateKeyUpdate({
+                    formData: formData,
+                })
+                .execute();  
+        } catch (error) {
+            console.error(tModal("error.draft"), error);
+        }
     }
 
     /**

--- a/src/modal/submit/MeetupCreateModalSubmit.ts
+++ b/src/modal/submit/MeetupCreateModalSubmit.ts
@@ -46,91 +46,12 @@ export class MeetupCreateModalSubmit extends AbstractModalSubmit {
         });
     }
 
-    protected checkModalInputs(fields: ModalSubmitFields): void {
-        //check pokémon
+    protected sanitizeModalInputs(fields: ModalSubmitFields): void {
         const pokemon: string = sanitizeTextInput(fields.getTextInputValue("pokemon"));
-
-        if (!pokemon.length) {
-            throw new Error(tModal("meetupCreate.submit.error.pokemonEmpty"));
-        }
-
-        if (checkForLinks(pokemon)) {
-            throw new Error(tCommon("error.linkDetected"));
-        }
-
-        //check location
         const location: string = sanitizeTextInput(fields.getTextInputValue("location"));
-
-        if (!location.length) {
-            throw new Error(tModal("meetupCreate.submit.error.locationEmpty"));
-        }
-
-        if (checkForLinks(location)) {
-            throw new Error(tCommon("error.linkDetected"));
-        }
-
-        //check time
-        const time: string = fields.getTextInputValue("time");
-
-        if (!time.length) {
-            throw new Error(tModal("meetupCreate.submit.error.timeEmpty"));
-        }
-
-        const timeRegexp = new RegExp("^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$");
-
-        if (!timeRegexp.test(time)) {
-            throw new Error(tModal("meetupCreate.submit.error.timeWrongFormat"));
-        }
-
-        const timeParts: string[] = time.split(":");
-        if (timeParts.length !== 2) {
-            throw new Error(tModal("meetupCreate.submit.error.timeWrongFormat"));
-        }
-
-        const [hour, minute] = timeParts.map(Number);
-
-        const currentDate = new Date();
-        currentDate.setSeconds(0, 0);
-
-        //check date
-        const date: string = fields.getTextInputValue("date");
-
-        if (!date.length) {
-            throw new Error(tModal("meetupCreate.submit.error.dateEmpty"));
-        }
-
-        const dateRegexp = new RegExp("^(0?[1-9]|[12][0-9]|3[01])\.(0?[1-9]|1[0-2])$");
-
-        if (!dateRegexp.test(date)) {
-            throw new Error(tModal("meetupCreate.submit.error.dateWrongFormat"));
-        }
-
-        const dateParts: string[] = date.split(".");
-        if (dateParts.length !== 2) {
-            throw new Error(tModal("meetupCreate.submit.error.dateWrongFormat"));
-        }
-
-        const [day, month] = dateParts.map(Number);
-        const year: number = calculateYear(day, month);
-
-        const dateObject = new Date(year, month - 1, day, hour, minute);
-
-        if (dateObject.getDate() !== day || dateObject.getMonth() !== month - 1) {
-            throw new Error(tModal("meetupCreate.submit.error.dateInvalid"));
-        }
-
-        if (dateObject < currentDate) {
-            throw new Error(tModal("meetupCreate.submit.error.dateInThePast"));
-        }
-
-        //check note (optional)
+        const time: string = fields.getTextInputValue("time").trim();
+        const date: string = fields.getTextInputValue("date").trim();
         const note: string = sanitizeTextInput(fields.getTextInputValue("note"));
-
-        if (note.length > 0) {
-            if (checkForLinks(note)) {
-                throw new Error(tCommon("error.linkDetected"));
-            }
-        }
 
         //save inputs for later
         this.sanitizedInputs = {
@@ -140,6 +61,83 @@ export class MeetupCreateModalSubmit extends AbstractModalSubmit {
             date,
             note,
         };
+    }
+
+    protected validateModalInputs(): void {
+        const { pokemon, location, time, date, note } = this.sanitizedInputs;
+
+        //check pokémon
+        if (!pokemon.length) {
+            this.handleError(tModal("meetupCreate.submit.error.pokemonEmpty"));
+        }
+
+        if (checkForLinks(pokemon)) {
+            this.handleError(tCommon("error.linkDetected"));
+        }
+
+        //check location
+        if (!location.length) {
+            this.handleError(tModal("meetupCreate.submit.error.locationEmpty"));
+        }
+
+        if (checkForLinks(location)) {
+            this.handleError(tCommon("error.linkDetected"));
+        }
+
+        //check time
+        if (!time.length) {
+            this.handleError(tModal("meetupCreate.submit.error.timeEmpty"));
+        }
+
+        const timeRegexp = new RegExp("^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$");
+
+        if (!timeRegexp.test(time)) {
+            this.handleError(tModal("meetupCreate.submit.error.timeWrongFormat"));
+        }
+
+        const timeParts: string[] = time.split(":");
+        if (timeParts.length !== 2) {
+            this.handleError(tModal("meetupCreate.submit.error.timeWrongFormat"));
+        }
+
+        const [hour, minute] = timeParts.map(Number);
+
+        const currentDate = new Date();
+        currentDate.setSeconds(0, 0);
+
+        //check date
+        if (!date.length) {
+            this.handleError(tModal("meetupCreate.submit.error.dateEmpty"));
+        }
+
+        const dateRegexp = new RegExp("^(0?[1-9]|[12][0-9]|3[01])\.(0?[1-9]|1[0-2])$");
+
+        if (!dateRegexp.test(date)) {
+            this.handleError(tModal("meetupCreate.submit.error.dateWrongFormat"));
+        }
+
+        const dateParts: string[] = date.split(".");
+        if (dateParts.length !== 2) {
+            this.handleError(tModal("meetupCreate.submit.error.dateWrongFormat"));
+        }
+
+        const [day, month] = dateParts.map(Number);
+        const year: number = calculateYear(day, month);
+
+        const dateObject = new Date(year, month - 1, day, hour, minute);
+
+        if (dateObject.getDate() !== day || dateObject.getMonth() !== month - 1) {
+            this.handleError(tModal("meetupCreate.submit.error.dateInvalid"));
+        }
+
+        if (dateObject < currentDate) {
+            this.handleError(tModal("meetupCreate.submit.error.dateInThePast"));
+        }
+
+        //check note (optional)
+        if (note.length > 0 && checkForLinks(note)) {
+            this.handleError(tCommon("error.linkDetected"));
+        }
     }
 
     /**
@@ -258,6 +256,9 @@ export class MeetupCreateModalSubmit extends AbstractModalSubmit {
         //schedule meetup list channel reset
         scheduleManager.scheduleResetMeetupList();
 
+        //remove modal input draft
+        await this.deleteModalInputDraft();
+
         //create success embed
         await postSuccess(
             interaction,
@@ -293,6 +294,10 @@ export class MeetupCreateModalSubmit extends AbstractModalSubmit {
         }
 
         return toSaveDate;
+    }
+
+    protected setDraftCustomID(): void {
+        this.draftCustomID = "meetup_create";
     }
 
     private async createMeetupRole(meetupID: number): Promise<Role | null> {

--- a/src/modal/submit/MeetupEditModalSubmit.ts
+++ b/src/modal/submit/MeetupEditModalSubmit.ts
@@ -10,17 +10,17 @@ import {
 } from "discord.js";
 import { getGuild } from "../../cache/guild";
 import { getMeetupInfoChannel } from "../../cache/meetupChannels";
+import { InteractionResponseMode } from "../../constant/interactionResponseMode";
 import { db } from "../../database/Database";
 import { MeetupRow } from "../../database/table/Meetup";
 import { tMeetup } from "../../i18n";
+import { scheduleManager } from "../../manager/ScheduleManager";
 import { assertMeetupIDIsValid } from "../../permission/assertMeetupIDIsValid";
 import { assertUserIsMeetupCreatorOrConfig } from "../../permission/assertUserIsMeetupCreatorOrConfig";
 import { getDynamicData } from "../../util/getDynamicIDData";
 import { editMeetupInfoEmbed } from "../../util/meetup/editMeetupInfoEmbed";
 import { prepareEmbedMessage } from "../../util/postEmbeds";
 import { MeetupCreateModalSubmit } from "./MeetupCreateModalSubmit";
-import { InteractionResponseMode } from "../../constant/interactionResponseMode";
-import { scheduleManager } from "../../manager/ScheduleManager";
 
 /**
  * Handles Edit Modal submits
@@ -139,6 +139,12 @@ export class MeetupEditModalSubmit extends MeetupCreateModalSubmit {
 
         //schedule meetup list channel reset
         scheduleManager.scheduleResetMeetupList();
+    }
+
+    protected setDraftCustomID(): void {
+        const meetup = this.additionalData.meetup as MeetupRow;
+
+        this.draftCustomID = "meetup_edit:" + meetup.meetupID;
     }
 
     private async sendDifferencesMessage(

--- a/src/modal/submit/NoticeCreateModalSubmit.ts
+++ b/src/modal/submit/NoticeCreateModalSubmit.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, MessageFlags, ModalSubmitFields, ModalSubmitInteraction } from "discord.js";
+import { EmbedBuilder, ModalSubmitFields, ModalSubmitInteraction } from "discord.js";
 import { getMeetupCreateChannel } from "../../cache/meetupChannels";
 import { tModal } from "../../i18n";
 import { noticeTypeMap } from "../../map/noticeTypeMap";
@@ -19,29 +19,40 @@ export class NoticeCreateModalSubmit extends AbstractModalSubmit {
         assertUserHasMeetupConfigRole(interaction);
     }
 
-    protected checkModalInputs(fields: ModalSubmitFields): void {
-        //check title
+    protected sanitizeModalInputs(fields: ModalSubmitFields): void {
         const title: string = sanitizeTextInput(fields.getTextInputValue("title"));
+        const description: string = fields.getTextInputValue("description").trim();
 
+        const typeValues: readonly string[] = fields.getStringSelectValues("type");
+        const type: string = typeValues[0] ?? "";
+
+        //save inputs for later
+        this.sanitizedInputs = {
+            title,
+            description,
+            type,
+        };
+    }
+
+    protected checkModalInputs(fields: ModalSubmitFields): void {
+        const { title, description, type } = this.sanitizedInputs;
+        
+        //check title
         if (!title.length) {
             throw new Error(tModal("noticeCreate.submit.error.titleEmpty"));
         }
 
         //check description
-        const description: string = fields.getTextInputValue("description").trim();
-
         if (!description.length) {
             throw new Error(tModal("noticeCreate.submit.error.descriptionEmpty"));
         }
 
         //check type
-        const typeValues: readonly string[] = fields.getStringSelectValues("type");
+        const typeValues: Set<string> = new Set(fields.getStringSelectValues("type"));
 
-        if (!typeValues.length) {
-            throw new Error(tModal("noticeCreate.submit.error.typeEmpty"));
+        if(!typeValues.has(type)) {
+            throw new Error(tModal("noticeCreate.submit.error.invalidType"));
         }
-
-        const type: string = typeValues[0];
 
         if (!type.length) {
             throw new Error(tModal("noticeCreate.submit.error.typeEmpty"));
@@ -66,6 +77,9 @@ export class NoticeCreateModalSubmit extends AbstractModalSubmit {
         if (type === "tutorial") {
             color = noticeTypeMap.get("tutorial")!;
         }
+        
+        //remove modal input draft
+        await this.deleteModalInputDraft();
 
         //post embed
         const embed: EmbedBuilder = prepareEmbedMessage(description, title, color);


### PR DESCRIPTION
Closes #52 

While I typically prefer a more atomic database design, the draft data is never queried on a field level and is only used to restore modal inputs. To keep the implementation simple, all form values are stored as a single JSON object per draft.